### PR TITLE
fixed parse error when chat.id is bigger than Int

### DIFF
--- a/telegramium-core/src/main/scala/telegramium/bots/Chat.scala
+++ b/telegramium-core/src/main/scala/telegramium/bots/Chat.scala
@@ -8,7 +8,7 @@ final case class Chat(
                         * smaller than 52 bits, so a signed 64 bit integer or
                         * double-precision float type are safe for storing this
                         * identifier.*/
-                      id: Int,
+                      id: Long,
                       /** Type of chat, can be either “private”, “group”,
                         * “supergroup” or “channel”*/
                       `type`: String,


### PR DESCRIPTION
	when bot was added to public group with
	id = -1001474417851 parsing failed
	fixed it